### PR TITLE
Persist functions were renamed

### DIFF
--- a/spatial_entities/spatial_entities_anchor.gd
+++ b/spatial_entities/spatial_entities_anchor.gd
@@ -71,7 +71,7 @@ func _on_spatial_tracking_state_changed(new_state) -> void:
 		# Make this persistent, this will callback UUID changed on the anchor,
 		# we can then store our scene path which we've already applied to our
 		# tracked scene.
-		OpenXRSpatialAnchorCapability.make_anchor_persistent(anchor_tracker)
+		OpenXRSpatialAnchorCapability.persist_anchor(anchor_tracker)
 
 func _on_uuid_changed() -> void:
 	_update_description()

--- a/spatial_entities/spatial_entities_manager.gd
+++ b/spatial_entities/spatial_entities_manager.gd
@@ -84,7 +84,7 @@ static func remove_spatial_anchor(p_anchor : XRAnchor3D) -> void:
 			if SpatialUuidDb:
 				SpatialUuidDb.remove_uuid(anchor_tracker.uuid)
 
-			var future_result = OpenXRSpatialAnchorCapability.make_anchor_unpersistent(anchor_tracker)
+			var future_result = OpenXRSpatialAnchorCapability.unpersist_anchor(anchor_tracker)
 			var success : bool = await future_result.completed
 
 			if success:


### PR DESCRIPTION
Latest version of https://github.com/godotengine/godot/pull/107391 our persistence functions were renamed to something more sensible,

This changes the naming in the demo.